### PR TITLE
Added KaTeX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Serene is a simple and clean blog theme for Static-Site-Generator [Zola](https:/
 - Web analytics
 - Projects page
 - Easily customize
+- Mathematical notations using KaTeX
 
 ## How to use
 

--- a/example-config.toml
+++ b/example-config.toml
@@ -67,7 +67,6 @@ blur_effect = true               # Whether to turn on blur effect on navigation 
 back_to_top_button = true        # Whether to show Back-To-Top button
 progress_bar = true              # Whether to show reading progress bar
 cc_license = false               # Whether to show Creative-Commons statement [Can be overridden by page config]
-math = false                     # Enabling KaTeX globally is NOT recommended. Enable it per-page basis
 cc_license_statement = "This work is licensed under [CC BY-NC-SA 4.0](http://creativecommons.org/licenses/by-nc-sa/4.0/)."  # The Creative-Commons statement
 outdate_warn = false             # Whether to show outdate warning [Can be overridden by page config]
 outdate_warn_days = 120          # How many days will a post be outdated [Can be overridden by page config]

--- a/example-config.toml
+++ b/example-config.toml
@@ -67,6 +67,7 @@ blur_effect = true               # Whether to turn on blur effect on navigation 
 back_to_top_button = true        # Whether to show Back-To-Top button
 progress_bar = true              # Whether to show reading progress bar
 cc_license = false               # Whether to show Creative-Commons statement [Can be overridden by page config]
+math = false                     # Enabling KaTeX globally is NOT recommended. Enable it per-page basis
 cc_license_statement = "This work is licensed under [CC BY-NC-SA 4.0](http://creativecommons.org/licenses/by-nc-sa/4.0/)."  # The Creative-Commons statement
 outdate_warn = false             # Whether to show outdate warning [Can be overridden by page config]
 outdate_warn_days = 120          # How many days will a post be outdated [Can be overridden by page config]

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -33,7 +33,7 @@
     <script>var _hmt = _hmt || [];(function() {  var hm = document.createElement("script");  hm.src = "https://hm.baidu.com/hm.js?{{ config.extra.baidu_tongji.token }}";  var s = document.getElementsByTagName("script")[0];   s.parentNode.insertBefore(hm, s);})();</script>
     {%- endif %}
     {# KaTeX support #}
-    {% if config.extra.math or section.extra.math or page.extra.math %}
+    {% if page.extra.math %}
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.css" integrity="sha384-MlJdn/WNKDGXveldHDdyRP1R4CTHr3FeuDNfhsLPYrq2t0UBkUdK2jyTnXPEK1NQ" crossorigin="anonymous">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.js" integrity="sha384-VQ8d8WVFw0yHhCk5E8I86oOhv48xLpnDZx5T9GogA/Y84DcCKWXDmSDfn13bzFZY" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/contrib/auto-render.min.js" integrity="sha384-+XBljXPPiv+OzfbB3cVmLHf4hdUFHlWNZN5spNQ7rmHTXpd7WvJum6fIACpNNfIR" crossorigin="anonymous"></script>

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -32,6 +32,28 @@
     {% if config.extra.analytics == 'baidu_tongji' -%}
     <script>var _hmt = _hmt || [];(function() {  var hm = document.createElement("script");  hm.src = "https://hm.baidu.com/hm.js?{{ config.extra.baidu_tongji.token }}";  var s = document.getElementsByTagName("script")[0];   s.parentNode.insertBefore(hm, s);})();</script>
     {%- endif %}
+    {# KaTeX support #}
+    {% if config.extra.math or section.extra.math or page.extra.math %}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.css" integrity="sha384-MlJdn/WNKDGXveldHDdyRP1R4CTHr3FeuDNfhsLPYrq2t0UBkUdK2jyTnXPEK1NQ" crossorigin="anonymous">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/katex.min.js" integrity="sha384-VQ8d8WVFw0yHhCk5E8I86oOhv48xLpnDZx5T9GogA/Y84DcCKWXDmSDfn13bzFZY" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.2/dist/contrib/auto-render.min.js" integrity="sha384-+XBljXPPiv+OzfbB3cVmLHf4hdUFHlWNZN5spNQ7rmHTXpd7WvJum6fIACpNNfIR" crossorigin="anonymous"></script>
+    <script>
+        document.addEventListener("DOMContentLoaded", function() {
+            renderMathInElement(document.body, {
+            // customised options
+            // • auto-render specific keys, e.g.:
+            delimiters: [
+                {left: '$$', right: '$$', display: true},
+                {left: '$', right: '$', display: false},
+                {left: '\\(', right: '\\)', display: false},
+                {left: '\\[', right: '\\]', display: true}
+            ],
+            // • rendering keys, e.g.:
+            throwOnError : false
+            });
+        });
+    </script>
+    {% endif %}
 </head>
 
 <body>


### PR DESCRIPTION
This pull request fixes #3 

You can enable the KaTeX support globally, per-section or per-page basis.

### Enable Globally

To enable the KaTeX support globally, add `math = true` under `[extra]` of the `config.toml`
at your site root. Now every section and page of your site will load the KaTeX [autorender extension](https://katex.org/docs/autorender.html).

```toml
[extra]
math = true
```

### Per-section Basis

To enable the KaTeX support in a particular section, add `math = true` under `[extra]` in the `[SECTION_NAME]/_index.md`. Now every page under this section will load the KaTeX
[autorender extension](https://katex.org/docs/autorender.html).

```md
+++
[extra]
math = true
+++
```

### Per-page Basis

To enable the KaTeX support in a particular page, add `math = true` under `[extra]` in the page's 
frontmatter. Now this page will load the KaTeX [autorender extension](https://katex.org/docs/autorender.html).

```markdown
+++
[extra]
math = true
+++
```

It is a good practice to enable KaTeX support on a per-page basis, since this will only load the
required files on that particular page, without affecting the page load speed of other pages.
If your site is not math-heavy, please do NOT enable this feature globally or per-section basis.

## Usage

Wrap any [valid](https://katex.org/docs/supported.html) KaTeX syntax with `$...$` for inline 
Mathematics and `$$...$$` for block Mathematics.

### Inline Mathematics

This is the most beautiful equation I've ever seen: $e^{i\pi}+1=0$

### Block Mathematics

Some Mathematics in display mode is fair enough:

$$
\int_0^1 x^2 dx
$$