### PR TITLE
feat: display_tags and truncate_summary options

### DIFF
--- a/USAGE-zh_CN.md
+++ b/USAGE-zh_CN.md
@@ -76,6 +76,7 @@ generate_feed = true
 
 [extra]
 lang = 'en'
+display_tags = true
 +++
 ```
 

--- a/USAGE-zh_CN.md
+++ b/USAGE-zh_CN.md
@@ -233,9 +233,9 @@ lang = 'en'
   more post content...
   ```
 
-- 推荐在文章中合适的位置（例如第一个段落之后）添加一行 `<!-- more -->` ，其前面的内容将作为页面的描述，有助于 SEO
+- 你可以添加一行`<!-- more -->`, 在其前面的内容会成为文章的总结/描述, 可以在 `myblog/content/blog/_index.md` 设置 `truncate_summary = ture` 来让其在最终的文章网页上不显示
 
-- 文章文件在 `myblog/content/blog` 下创建，写完后将 draft 改为 true 即可
+- 文章文件在 `myblog/content/blog` 下创建，写完后将 draft 改为 false 即可
 
 ### Shortcodes
 

--- a/USAGE-zh_CN.md
+++ b/USAGE-zh_CN.md
@@ -77,6 +77,7 @@ generate_feed = true
 [extra]
 lang = 'en'
 display_tags = true
+truncate_summary = false
 +++
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -76,6 +76,7 @@ generate_feed = true
 
 [extra]
 lang = 'en'
+display_tags = true
 +++
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -77,6 +77,7 @@ generate_feed = true
 [extra]
 lang = 'en'
 display_tags = true
+truncate_summary = false         # Do not show post summary in blog post.
 +++
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -77,7 +77,7 @@ generate_feed = true
 [extra]
 lang = 'en'
 display_tags = true
-truncate_summary = false         # Do not show post summary in blog post.
+truncate_summary = false
 +++
 ```
 
@@ -236,9 +236,9 @@ Copy the contents of `myblog/themes/serene/config.example.toml` to `myblog/confi
   more post content...
   ```
 
-- It is recommended to add a line `<!-- more -->` at the appropriate position in the post (such as after the first paragraph), and the content before it will be used as the description of the page, which is helpful for SEO
+- You can add a `<!-- more -->` line, the content before it will become the summary/description of the post. You can set `truncate_summary = true` in `myblog/content/blog/_index.md` to remove the summary from the post webpage.
 
-- Post files are created under `myblog/content/blog`, after done writing, change `draft` to true
+- Post files are created under `myblog/content/blog`, after done writing, change `draft` to false
 
 ### Shortcodes
 

--- a/templates/post.html
+++ b/templates/post.html
@@ -53,7 +53,9 @@
           {% endif -%}
         </div>
 
-        {% if page.taxonomies.tags is defined %}
+        {% if page.extra.display_tags is defined %}{% set display_tags = page.extra.display_tags %}{% elif section.extra.display_tags is defined %}{% set display_tags = section.extra.display_tags %}{% else %}{% set display_tags = true %}{% endif %}
+
+        {% if page.taxonomies.tags is defined and display_tags == true %}
         <div id="tags">
           {% for tag in page.taxonomies.tags -%}
           {% set tag_slugify = tag | slugify -%}

--- a/templates/post.html
+++ b/templates/post.html
@@ -80,7 +80,13 @@
       </blockquote>
       {% endif %}
 
-      {{ page.content | safe }}
+      {% if page.extra.truncate_summary is defined %}{% set truncate_summary = page.extra.truncate_summary %}{% elif section.extra.truncate_summary is defined %}{% set truncate_summary = section.extra.truncate_summary %}{% else %}{% set truncate_summary = false %}{% endif %}
+
+      {% if truncate_summary == true and page.summary %}
+        {{ page.content | trim_start_matches(pat=page.summary) | safe }}
+      {% else %}
+        {{ page.content | safe }}
+      {% endif %}
     </article>
 
     {% if page.extra.comment is defined %}{% set show_comment = page.extra.comment %}{% else %}{% set show_comment = config.extra.comment %}{% endif %}


### PR DESCRIPTION
Closes #40.

Since these options only apply to blogs (not projects), I made options available in `blog/_index.md` and `<post-name>.md` (cannot be set from `config.toml`).
If you want to change the docs you can push commits to this pr, I rebase well and you just push two commits without squashing.