### PR TITLE
Correct highlight_themes path in USAGE.md

### DIFF
--- a/USAGE-zh_CN.md
+++ b/USAGE-zh_CN.md
@@ -123,7 +123,7 @@ lang = 'en'
 
 ### 代码高亮
 
-- 将 `myblog/themes/serene/static/highlight_themes` 目录复制到 `myblog/static/highlight_themes`
+- 将 `myblog/themes/serene/highlight_themes` 目录复制到 `myblog/highlight_themes`
 
 - 如果你将 `config.toml` 中的 `highlight_theme` 设置为 zola 的 [内置高亮主题](https://www.getzola.org/documentation/getting-started/configuration/#syntax-highlighting) 之一，浅色和深色模式都将使用该主题
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -125,7 +125,7 @@ Copy the contents of `myblog/themes/serene/config.example.toml` to `myblog/confi
 
 ### Code highlight
 
-- Copy `myblog/themes/serene/static/highlight_themes` directory to `myblog/static/highlight_themes`.
+- Copy `myblog/themes/serene/highlight_themes` directory to `myblog/highlight_themes`.
 
 - If you set `highlight_theme` in `config.toml` to one of zola's [built-in highlight themes](https://www.getzola.org/documentation/getting-started/configuration/#syntax-highlighting), you will get that theme used in both light and dark mode.
 


### PR DESCRIPTION
In `USAGE.md` instructions are provided to copy the theme's `/highlight_themes/` folder to `/myblog/static/highlight_themes/`.

The instructions indicate that `/highlight_themes/` is found in `myblog/themes/serene/static/` but it is found one directory up in the theme root.

This changes `USAGE.md` so that the instructions are to copy `myblog/themes/serene/highlight_themes/` to `myblog/highlight_themes`, which is presumably the intention.