### PR TITLE
removed extra / in url when viewing tags

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -101,7 +101,7 @@
           <div id="tags">
             {% for tag in page.taxonomies.tags -%}
             {% set tag_slugify = tag | slugify -%}
-            <a href="{{ config.base_url ~ '/tags/' ~ tag_slugify }}"><span>#</span>{{ tag }}</a>
+            <a href="{{ config.base_url ~ 'tags/' ~ tag_slugify }}"><span>#</span>{{ tag }}</a>
             {%- endfor %}
           </div>
           {% endif %}

--- a/templates/tags/single.html
+++ b/templates/tags/single.html
@@ -15,7 +15,7 @@
   <main>
     <div class="title">
       <span># {{ term.name }}</span>
-      <a href="{{ config.base_url ~ '/tags' }}">All Tags</a>
+      <a href="{{ config.base_url ~ 'tags' }}">All Tags</a>
     </div>
     <div class="post-list">
       {% for post in term.pages %}


### PR DESCRIPTION
The URL path when you are:

1. looking at all tags
2. looking at 1 tag

have an extra / i.e. www.domain.com//tags/ or www.domain.com//tags/tag_1/