### PR TITLE
Replace zero byte files in `categories/` with copies from `tags/` dir

### DIFF
--- a/templates/categories/list.html
+++ b/templates/categories/list.html
@@ -1,0 +1,32 @@
+{% extends "_base.html" %}
+
+{% block page %}tag-list{% endblock page%}
+{% block lang -%}
+{% set blog_section_path = config.extra.blog_section_path | trim_start_matches(pat="/") %}
+{% set section_md_path = blog_section_path ~ "/_index.md"%}
+{% set section = get_section(path=section_md_path, metadata_only=true) %}
+{%- if section.extra.lang %}{{ section.extra.lang }}{% else %}{{ lang }}{% endif -%}
+{%- endblock lang %}
+{% block title %}Categories{% endblock title %}
+
+{% block content %}
+{% include "_header.html" %}
+<div id="wrapper">
+  <main>
+    <div class="title">Categories</div>
+    <div>
+      <ul>
+      {% for category in terms -%}
+      <li>
+         <a
+            class="instant"
+            href="{{ category.permalink }}">{{ category.name | lower }}
+         </a>
+      </li>
+      {% endfor %}
+      </ul>
+    </div>
+  </main>
+  {% include "_footer.html" %}
+</div>
+{% endblock content %}

--- a/templates/categories/single.html
+++ b/templates/categories/single.html
@@ -1,0 +1,34 @@
+{% extends "_base.html" %}
+
+{% block page %}tag-single{% endblock page %}
+{% block lang -%}
+{% set blog_section_path = config.extra.blog_section_path | trim_start_matches(pat="/") %}
+{% set section_md_path = blog_section_path ~ "/_index.md"%}
+{% set section = get_section(path=section_md_path, metadata_only=true) %}
+{%- if section.extra.lang %}{{ section.extra.lang }}{% else %}{{ lang }}{% endif -%}
+{%- endblock lang %}
+{% block title %}{{section.title}}{% endblock title %}
+
+{% block content %}
+{% include "_header.html" %}
+<div id="wrapper">
+  <main class="layout-list">
+    <div class="title">
+      <span>{{ term.name }}</span>
+      <a
+         class="instant"
+         href="{{ config.base_url ~ '/categories' }}">(All Categories)
+      </a>
+    </div>
+    <div class="post-list">
+      {% for post in term.pages %}
+      <a class="post instant {% if post.extra.featured %}featured{% endif %}" href="{{ post.permalink }}">
+        <span>{{ post.title }}</span>
+        <span class="date">{{ post.date | date }}</span>
+      </a>
+      {% endfor %}
+    </div>
+  </main>
+  {% include "_footer.html" %}
+</div>
+{% endblock content %}


### PR DESCRIPTION
Hi,

Thank you for the work on putting together the _Serene_ theme.

The current contents of the `templates/categories/` directory is two zero byte files.  If you browse the `/categories` URL on a "live" Zola site that uses the _Serene_ theme (https://serene-demo.pages.dev/categories/ ), you get an empty page because of this.

The `/categories` URL with valid `single.html` and `list.html` pages will show a list of categories that have been configured for the site (`list.html`); if you click on a category from the list, it will show you all of the posts in that category (`single.html`).

All of the above is documented at https://www.getzola.org/documentation/templates/taxonomies/

You can see an example of a "working" categories page in a different Zola theme here:

https://deepthought-theme.netlify.app/categories/

For _Serene_, I "borrowed" the `list.html` and `single.html` pages from the `tags/` template directory, and refactored the two pages to work with categories instead of tags, and then replaced the two zero byte files in the `templates/categories` directory.

The page formatting of the `/categories` URLs looks a bit funny, since it uses the CSS for the `/tags` pages, but the `/categories` URL works for a Zola-generated site with the _Serene_ theme now.  I figured the formatting could be updated later on, "working" would be a good place to start.

