### PR TITLE
fix: use base_url for relative paths to enable hosting at non-root paths

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -8,12 +8,12 @@
   <meta name="color-scheme" content="light dark">
   {% block desc %}{% endblock desc %}
   <title>{% block title %}{% endblock title %}</title>
-  <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/img/favicon-16x16.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/img/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="{{ get_url(path='img/favicon-32x32.png') }}">
+  <link rel="icon" type="image/png" sizes="16x16" href="{{ get_url(path='img/favicon-16x16.png') }}">
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ get_url(path='img/apple-touch-icon.png') }}">
   {% include "_custom_font.html" %}
   {% include "_custom_css.html" %}
-  <link rel="stylesheet" href="/main.css">
+  <link rel="stylesheet" href="{{ get_url(path='main.css') }}">
   {% block head %}{% endblock head %}
   {% include "_head_extend.html" %}
 </head>
@@ -26,13 +26,13 @@
     if ((theme && theme == 'dark') || (!theme && match)) {
       document.body.classList.add('dark');
       const hl = document.querySelector('link#hl');
-      if (hl) hl.href = '/hl-dark.css';
+      if (hl) hl.href = '{{ get_url(path="hl-dark.css") }}';
     }
   </script>
   {% endif %}
   {% block content %}{% endblock content %}
   {% block script %}{% endblock script %}
-  <script src="/js/main.js"></script>
+  <script src="{{ get_url(path='js/main.js') }}"></script>
 </body>
 
 </html>

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -1,7 +1,7 @@
 <header {% if config.extra.blur_effect %} class="blur" {% endif %}>
   <div id="header-wrapper">
     <nav>
-      <a class="instant" href="/">{{ config.extra.id }}</a>
+      <a class="instant" href="{{ get_url(path="") }}">{{ config.extra.id }}</a>
       {% if config.extra.sections | length > 1 %}
         <button id="toggler" class="separator" aria-label="toggle expand">{{ config.extra.nav_separator }}</button>
       {% else %}
@@ -23,13 +23,13 @@
           {% elif not current_path is starting_with(section.path) %}
             {% set should_fold = true %}
           {% endif %}
-          <a class="instant {% if should_fold %}fold{% endif %}" href="{{ section.path }}">{{ section.name }}</a>
+          <a class="instant {% if should_fold %}fold{% endif %}" href="{{ get_url(path=section.path) }}">{{ section.name }}</a>
           {% if not loop.last %}<span class="wrap-separator fold">{{ config.extra.nav_wrapper_separator }}</span>{% endif %}
         {% endfor %}
         <span class="wrap right fold">{{ config.extra.nav_wrapper_right }}</span>
       {% else %}
         {% set section = config.extra.sections | first %}
-        <a class="instant" href="{{ section.path }}">{{ section.name }}</a>
+        <a class="instant" href="{{ get_url(path=section.path) }}">{{ section.name }}</a>
       {% endif %}
     </nav>
     <div id="btns">
@@ -45,7 +45,7 @@
         {% set_global rss_path = "/" ~ config.feed_filenames.0 %}
       {% endif %}
       {% if section.generate_feeds or config.generate_feeds %}
-      <a id="rss-btn" href="{{ rss_path }}" aria-label="rss feed">{{ rss_icon | safe }}</a>
+      <a id="rss-btn" href="{{ get_url(path=rss_path) }}" aria-label="rss feed">{{ rss_icon | safe }}</a>
       {% endif %}
       {% endif %}
 
@@ -73,7 +73,7 @@
 
 {% if blog_section_path is defined and section.path is starting_with(blog_section_path) %}
 {% if section.generate_feeds or config.generate_feeds %}
-{% set link = config.base_url ~ rss_path %}
+{% set link = get_url(path=rss_path) %}
 <dialog id="rss-mask">
   <div>
     <a href="{{ link }}">{{ link }}</a>

--- a/templates/home.html
+++ b/templates/home.html
@@ -10,7 +10,11 @@
 
 {% block head %}
 {% if config.markdown.highlight_theme == "css" %}
-<link id="hl" rel="stylesheet" type="text/css" href="/hl-{% if config.extra.force_theme == "dark" %}dark{% else %}light{% endif %}.css" />
+  {% if config.extra.force_theme == "dark" %}
+    <link id="hl" rel="stylesheet" type="text/css" href="{{ get_url(path='hl-dark.css') }}" />
+  {% else %}
+    <link id="hl" rel="stylesheet" type="text/css" href="{{ get_url(path='hl-light.css') }}" />
+  {% endif %}
 {% endif %}
 {% if section.extra.math %}
   {{ macro_math::math_render(style = section.extra.math) }}
@@ -22,7 +26,7 @@
   <main>
     <section id="info">
       {% if config.extra.display_avatar %}
-      <img src="{{ config.extra.avatar }}" alt="avatar">
+      <img src="{{ get_url(path=config.extra.avatar) }}" alt="avatar">
       {% endif %}
       <div id="text">
         <div>
@@ -39,7 +43,7 @@
     <section id="links">
       <div id="left">
         {% for section in config.extra.sections %}
-        <a href="{{ section.path }}" {% if section.is_external %}target="_blank" rel='noreferrer noopener'{% else %}class="instant"{% endif %}>{{ section.name }}</a>
+        <a href="{{ get_url(path=section.path) }}" {% if section.is_external %}target="_blank" rel='noreferrer noopener'{% else %}class="instant"{% endif %}>{{ section.name }}</a>
         {% endfor %}
       </div>
       <div id="right">
@@ -50,44 +54,44 @@
           {{ icon | safe }}
         </a>
         {% endfor %}
-		    {% if not config.extra.force_theme %}
+        {% if not config.extra.force_theme %}
         {% set moon_icon = load_data(path="static/icon/moon.svg") %}
         {% set sun_icon = load_data(path="static/icon/sun.svg") %}
         <button id="theme-toggle" aria-label="theme switch">
           <span class="moon-icon">{{ moon_icon | safe }}</span>
           <span class="sun-icon">{{ sun_icon | safe }}</span>
         </button>
-		    {% endif %}
+        {% endif %}
       </div>
     </section>
-      <section id="brief" class="prose">
-        {{ section.content | trim | safe }}
-      </section>
+    <section id="brief" class="prose">
+      {{ section.content | trim | safe }}
+    </section>
     {% if config.extra.recent %}
-      {% set blog_section_path = config.extra.blog_section_path | trim_start_matches(pat="/") %}
-      {% set section_md_path = blog_section_path ~ "/_index.md" %}
-      {% set blog_section = get_section(path=section_md_path) %}
-      <section class="layout-list">
-        <div class="post-list">
-          {% for post in blog_section.pages | slice(end=config.extra.recent_max) %}
-          <a class="post instant {% if post.extra.featured %}featured{% endif %}" href="{{ post.permalink }}">
-            <span>{{ post.title }}</span>
-            <span class="line"></span>
-            <span class="date">{{ post.date | date}}</span>
-          </a>
-          {% endfor %}
-        </div>
-        <div class="read-more">
-          <a class="instant" href="{{ config.extra.blog_section_path }}">{{ config.extra.recent_more_text }}</a>
-        </div>
-      </section>
-    {% endif %}
+    {% set blog_section_path = config.extra.blog_section_path | trim_start_matches(pat="/") %}
+    {% set section_md_path = blog_section_path ~ "/_index.md" %}
+    {% set blog_section = get_section(path=section_md_path) %}
+    <section class="layout-list">
+      <div class="post-list">
+        {% for post in blog_section.pages | slice(end=config.extra.recent_max) %}
+        <a class="post instant {% if post.extra.featured %}featured{% endif %}" href="{{ post.permalink }}">
+          <span>{{ post.title }}</span>
+          <span class="line"></span>
+          <span class="date">{{ post.date | date}}</span>
+        </a>
+        {% endfor %}
+      </div>
+      <div class="read-more">
+        <a class="instant" href="{{ config.extra.blog_section_path }}">{{ config.extra.recent_more_text }}</a>
+      </div>
+    </section>
+  {% endif %}
   </main>
 </div>
 {% endblock content %}
 
 {% block script %}
-<script src="/js/lightense.min.js"></script>
+<script src="{{ get_url(path='js/lightense.min.js') }}"></script>
 {% if section.extra.mermaid %}
 <script type="module">
   import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';


### PR DESCRIPTION
Address issue #67 to allow `base_url` to be of form `https://example.com/mysite` and still have internal theme navigation working.

Added calls to Zola's [get_url function](https://www.getzola.org/documentation/templates/overview/#get-url) to parse full url in standardised way.

For this, modified links in`home.html`, `_header.html`, and `_base.html`. There may be other places that need fixing, but I haven't come across any others yet in my testing.

For conditional rendering of css dark / light theme in `_base.html`, I had to break the if/else handling into more explicit separate steps rather than single line, as otherwise `get_url` broke it - sorry that this is less elegant!