### PR TITLE
Fix page class when using force_theme = "dark"

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -18,7 +18,7 @@
   {% include "_head_extend.html" %}
 </head>
 
-<body class="{% block page %}{% endblock page%}{% if config.extra.force_theme == "dark" %}dark{% endif %}">
+<body class="{% block page %}{% endblock page%}{% if config.extra.force_theme == "dark" %} dark{% endif %}">
   {% if not config.extra.force_theme %}
   <script>
     const theme = sessionStorage.getItem('theme');


### PR DESCRIPTION
Adds a space when using `force_theme = "dark"` in the config. This allows the classes for the page to actually work as intended.