### PR TITLE
Add Content-Type header to emoji react fetch

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -217,6 +217,9 @@ function enableReaction() {
     try {
       const resp = await fetch(endpoint, {
         method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify({ slug, target, reacted: !reacted }),
       });
       if (resp.status === 200) {


### PR DESCRIPTION
This adds a missing Content-Type header for the emoji reactions. My API was rejecting the default `text/plain` content type here