### PR TITLE
Fix external links on homepage

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -58,7 +58,7 @@
     <section id="links">
       <div id="left">
         {% for section in config.extra.sections %}
-        <a href="{{ get_url(path=section.path) }}" {% if section.is_external %}target="_blank" rel='noreferrer noopener'{% else %}class="instant"{% endif %}>{{ section.name }}</a>
+        <a {% if section.is_external %}href="{{ section.path }}" target="_blank" rel='noreferrer noopener'{% else %}href="{{ get_url(path=section.path) }}" class="instant"{% endif %}>{{ section.name }}</a>
         {% endfor %}
       </div>
       <div id="right">

--- a/templates/home.html
+++ b/templates/home.html
@@ -82,13 +82,13 @@
     <section id="brief" class="prose">
       {{ section.content | trim | safe }}
     </section>
-    {% if sectionextra.recent %}
+    {% if section.extra.recent %}
     {% set blog_section_path = config.extra.blog_section_path | trim_start_matches(pat="/") %}
     {% set section_md_path = blog_section_path ~ "/_index.md" %}
     {% set blog_section = get_section(path=section_md_path) %}
     <section class="layout-list">
       <div class="post-list">
-        {% for post in blog_section.pages | slice(end=sectionextra.recent_max) %}
+        {% for post in blog_section.pages | slice(end=section.extra.recent_max) %}
         <a class="post instant {% if post.extra.featured %}featured{% endif %}" href="{{ post.permalink }}">
           <span>{{ post.title }}</span>
           <span class="line"></span>
@@ -97,7 +97,7 @@
         {% endfor %}
       </div>
       <div class="read-more">
-        <a class="instant" href="{{ config.extra.blog_section_path }}">{{ sectionextra.recent_more_text }}</a>
+        <a class="instant" href="{{ config.extra.blog_section_path }}">{{ section.extra.recent_more_text }}</a>
       </div>
     </section>
   {% endif %}


### PR DESCRIPTION
Fix external links on the homepage (where `is_external` is true) from being rendered as relative from the `base_url` to instead be the absolute URL set in the `path`
This slightly modifies the change in https://github.com/isunjn/serene/pull/68

I decided to move the href inside the existing conditions (and duplicating the href) rather than doubling up the condition to keep a single href