### PR TITLE
refactor: Remove static/ prefix from icon paths

### DIFF
--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -25,8 +25,8 @@
     {% endif %}
 
     {% if not config.extra.force_theme %}
-    {% set moon_icon = load_data(path="static/icon/moon.svg") %}
-    {% set sun_icon = load_data(path="static/icon/sun.svg") %}
+    {% set moon_icon = load_data(path="icon/moon.svg") %}
+    {% set sun_icon = load_data(path="icon/sun.svg") %}
     <button id="theme-toggle" aria-label="theme switch">
       <span class="moon-icon">{{ moon_icon | safe }}</span>
       <span class="sun-icon">{{ sun_icon | safe }}</span>
@@ -41,8 +41,8 @@
 <dialog id="rss-mask">
   <div>
     <a href="{{ link }}">{{ link }}</a>
-    {% set copy_icon = load_data(path="static/icon/copy.svg") %}
-    {% set check_icon = load_data(path="static/icon/check.svg") %}
+    {% set copy_icon = load_data(path="icon/copy.svg") %}
+    {% set check_icon = load_data(path="icon/check.svg") %}
     <button autofocus aria-label="copy" data-link="{{ link }}" data-copy-icon="{{ copy_icon }}" data-check-icon="{{ check_icon }}" >
       {{ copy_icon | safe }}
     </button>

--- a/templates/home.html
+++ b/templates/home.html
@@ -64,14 +64,14 @@
       <div id="right">
         {% for link in section.extra.links %}
         <a href="{{ link.url }}" aria-label="{{ link.name }}" target="_blank" rel='noreferrer noopener'>
-          {% set icon_path = "static/icon/" ~ link.icon ~ ".svg" %}
+          {% set icon_path = "icon/" ~ link.icon ~ ".svg" %}
           {% set icon = load_data(path=icon_path) %}
           {{ icon | safe }}
         </a>
         {% endfor %}
         {% if not section.extra.footer and not config.extra.force_theme %}
-        {% set moon_icon = load_data(path="static/icon/moon.svg") %}
-        {% set sun_icon = load_data(path="static/icon/sun.svg") %}
+        {% set moon_icon = load_data(path="icon/moon.svg") %}
+        {% set sun_icon = load_data(path="icon/sun.svg") %}
         <button id="theme-toggle" aria-label="theme switch">
           <span class="moon-icon">{{ moon_icon | safe }}</span>
           <span class="sun-icon">{{ sun_icon | safe }}</span>

--- a/templates/macros/prose.html
+++ b/templates/macros/prose.html
@@ -9,7 +9,7 @@
 
 {% macro callout(name) %}
 <blockquote class="callout {{ name }} {% if title %}has-title{% else %}no-title{% endif %}">
-  {% set icon = load_data(path="static/icon/" ~ name ~ ".svg") %}
+  {% set icon = load_data(path="icon/" ~ name ~ ".svg") %}
   {% if title %}
   <p class="title">
     <span class="icon">

--- a/templates/post.html
+++ b/templates/post.html
@@ -74,7 +74,7 @@
     {% endif %}
     {% if section.extra.back_to_top %}
     <button id="back-to-top" aria-label="back to top">
-      {% set icon = load_data(path="static/icon/arrow-up.svg") %}
+      {% set icon = load_data(path="icon/arrow-up.svg") %}
       {{ icon | safe }}
     </button>
     {% endif %}
@@ -85,8 +85,8 @@
     <div>
       {% if page.extra.copy is defined %}{% set allow_copy = page.extra.copy %}{% else %}{% set allow_copy = section.extra.copy %}{% endif %}
       {% if allow_copy %}
-      {% set copy_icon = load_data(path="static/icon/copy.svg") %}
-      {% set check_icon = load_data(path="static/icon/check.svg") %}
+      {% set copy_icon = load_data(path="icon/copy.svg") %}
+      {% set check_icon = load_data(path="icon/check.svg") %}
       <div id="copy-cfg" style="display: none;" data-copy-icon="{{ copy_icon }}" data-check-icon="{{ check_icon }}"></div>
       {% endif %}
       <article class="prose">

--- a/templates/prose.html
+++ b/templates/prose.html
@@ -47,8 +47,8 @@
     {% include "_section_title.html" %}
     <div>
       {% if section.extra.copy %}
-      {% set copy_icon = load_data(path="static/icon/copy.svg") %}
-      {% set check_icon = load_data(path="static/icon/check.svg") %}
+      {% set copy_icon = load_data(path="icon/copy.svg") %}
+      {% set check_icon = load_data(path="icon/check.svg") %}
       <div id="copy-cfg" style="display: none;" data-copy-icon="{{ copy_icon }}" data-check-icon="{{ check_icon }}"></div>
       {% endif %}
       <article class="prose">

--- a/templates/shortcodes/quote.html
+++ b/templates/shortcodes/quote.html
@@ -1,5 +1,5 @@
 <blockquote class="quote">
-  {% set icon = load_data(path="static/icon/quote.svg") %}
+  {% set icon = load_data(path="icon/quote.svg") %}
   <div class="icon" style="display: none;">{{ icon | safe }}</div>
   <div class="content">{{ body | markdown | safe }}</div>
   {% if cite %}


### PR DESCRIPTION
Removes static/ prefix from icon paths, allowing Zola to find them in the theme's static directory automatically (`$base_directory` + `"themes"` + `$theme` + `"static/"` + `$path`).
This eliminates the need to copy icon files.
https://www.getzola.org/documentation/templates/overview/#file-searching-logic