### PR TITLE
feat: allow custom height and width for `figure` shortcodes

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -331,6 +331,11 @@ Zola supports some [annotations for code blocks](https://www.getzola.org/documen
   {{ figure(src="/path/to/img", alt="some alt text", via="https://example.com") }}
   ```
 
+  You can specify custom width and height for your figures:
+   ```md
+  {{ figure(src="/path/to/img", alt="some alt text", via="https://example.com", height="500", width="500") }}
+  ```
+
 - Use `quote` to display a special quote block, `cite` is optional:
 
   ```md

--- a/templates/shortcodes/figure.html
+++ b/templates/shortcodes/figure.html
@@ -1,5 +1,10 @@
 <figure>
-    <img src="{{ src }}" {% if alt %} alt="{{ alt }}"{% endif %}>
+    <img 
+        src="{{ src }}" 
+        {% if alt %} alt="{{ alt }}"{% endif %}
+        {% if height %} height="{{ height }}"{% endif %}
+        {% if width %} width="{{ width }}"{% endif %}
+    >
     {% if via %}
     <figcaption><a href="{{via}}">via</a></figcaption>
     {% else %}


### PR DESCRIPTION
Had this use-case for myself and made the same changes on my fork where I'm using serene.  

These changes were working on my website, but I don't know if there are any tests I should verify for this repo - let me know if this is fine.

Thanks!