### PR TITLE
feat: Optimize image sizes for figures

### DIFF
--- a/templates/shortcodes/figure.html
+++ b/templates/shortcodes/figure.html
@@ -1,3 +1,10 @@
+{% set src = src | default(value=path) %}
+{% if width is defined and height is defined %}
+  {% set op = op | default(value="fill") %}
+  {% set image = resize_image(path=path, width=width, height=height, op=op) %}
+  {% set src = image.url %}
+{% endif %}
+
 <figure>
     <img 
         src="{{ src }}" 


### PR DESCRIPTION
This is a more specific update related to https://github.com/isunjn/serene/pull/90 that automatically optimizes image sizes for figures.