### PR TITLE
fix: resolve colocated figure image URLs

### DIFF
--- a/templates/shortcodes/figure.html
+++ b/templates/shortcodes/figure.html
@@ -1,6 +1,15 @@
+{% if src is starting_with("/") or src is starting_with("http://") or src is starting_with("https://") or src is starting_with("//") or src is starting_with("data:") %}
+    {% set image_src = src %}
+{% elif page is defined and page.colocated_path %}
+    {% set image_src = get_url(path=page.colocated_path ~ src) %}
+{% elif section is defined and section.colocated_path %}
+    {% set image_src = get_url(path=section.colocated_path ~ src) %}
+{% else %}
+    {% set image_src = src %}
+{% endif %}
 <figure>
     <img
-        src="{{ src }}"
+        src="{{ image_src }}"
         {% if alt %} alt="{{ alt }}"{% endif %}
         {% if height %} height="{{ height }}"{% endif %}
         {% if width %} width="{{ width }}"{% endif %}


### PR DESCRIPTION
## Summary


• Raw output mode on: transcript text is shown for clean terminal selection.
Resolve relative image paths passed to the `figure` shortcode against the current page or section's colocated asset directory.

Absolute paths, external URLs, protocol-relative URLs, and data URLs continue to be used unchanged.

## Motivation

The `figure` shortcode currently outputs `src` as-is:

```html
<img src="image.png">
```

For a colocated page asset, this depends on the page URL ending with a trailing slash. For example, when both of these URLs are served:

- `/posts/example/`
- `/posts/example`

The image works on the first URL, but the second URL resolves `image.png` as `/posts/image.png` instead of `/posts/example/image.png`.

This can happen on static hosting platforms such as Vercel when trailing-slash redirects are not configured.

Zola provides `page.colocated_path` and `section.colocated_path` for resolving assets stored alongside Markdown files. This change uses those paths together with `get_url` to generate an absolute image URL.

## Behavior

Given:

```markdown
{{ figure(src="image.png", caption="Example") }}
```

The generated image URL changes from:

```html
<img src="image.png">
```

to:

```html
<img src="https://example.com/posts/example/image.png">
```

Existing forms remain unchanged:

```markdown
{{ figure(src="/img/example.png") }}
{{ figure(src="https://example.com/image.png") }}
{{ figure(src="//cdn.example.com/image.png") }}
{{ figure(src="data:image/png;base64,...") }}
```

## Testing

Tested with Zola 0.22.1:

- The site builds successfully.
- Relative page-bundle images produce absolute URLs.
- Root-relative image paths continue to work.
- Existing `alt`, `caption`, `width`, and `height` behavior is unchanged.
```

- Existing `alt`, `caption`, `width`, and `height` behavior is unchanged.